### PR TITLE
fix(readme): repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ This project is licensed under the [MIT License](LICENSE) — free to use, modif
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ClawDeckX/ClawDeckX&type=Date)](https://star-history.com/#ClawDeckX/ClawDeckX&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ClawDeckX/ClawDeckX&type=Date)](https://star-history.dera.page/#ClawDeckX/ClawDeckX&Date)
 
 <br>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -353,7 +353,7 @@ docker logs clawdeckx
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ClawDeckX/ClawDeckX&type=Date)](https://star-history.com/#ClawDeckX/ClawDeckX&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ClawDeckX/ClawDeckX&type=Date)](https://star-history.dera.page/#ClawDeckX/ClawDeckX&Date)
 
 <div align="center">
   <sub>Designed with ❤️ by ClawDeckX</sub>


### PR DESCRIPTION
The Star History chart in the README is currently broken because the underlying GitHub stargazer API no longer works as before. This updates the chart to use a working alternative, restoring the visualization on both README.md and README.zh-CN.md.